### PR TITLE
Add findModuleByPrototypes to BdApi

### DIFF
--- a/modules/BDApi.js
+++ b/modules/BDApi.js
@@ -291,6 +291,10 @@ class BdApi {
     return BdApi.findModule((module) => props.every((prop) => typeof module[prop] !== 'undefined'))
   }
 
+  static findModuleByPrototypes(...protos) {
+    return getModule(module => module.prototype && protos.every(proto => typeof module.prototype[proto] !== 'undefined'), false)
+  }
+
   static findModuleByDisplayName(displayName) {
     return getModuleByDisplayName(displayName, false)
   }


### PR DESCRIPTION
Adds missing findModuleByPrototypes function, should fix a few plugins throwing errors like [ShowSessions](https://github.com/Strencher/BetterDiscordStuff/tree/master/ShowSessions) or [VoiceChatNotifications](https://github.com/Strencher/BetterDiscordStuff/tree/master/VoiceChatNotifications)