### PR TITLE
Update manifest (because Replugged needs it)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "BetterDiscord plugin compatibility (bdCompat)",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "Adds support for running BetterDiscord plugins",
   "author": "intrnl & Juby210",
   "license": "MIT"


### PR DESCRIPTION
Replugged now needs a version update in manifest to actually pull changes. This change will make it so that people can actually pull the update in.